### PR TITLE
Add an optional parameter to configureForViewModel: that includes the traitCollection

### DIFF
--- a/BSWInterfaceKitDemo/AzzurriViewController.swift
+++ b/BSWInterfaceKitDemo/AzzurriViewController.swift
@@ -141,7 +141,7 @@ extension AzzurriViewController: ColumnFlowLayoutFactoryDataSource {
         guard let vm = dataSource.data[safe: indexPath.item] else {
             return cell
         }
-        cell.configureFor(viewModel: vm)
+        cell.configureFor(viewModel: vm, traitCollection: self.traitCollection)
         return cell
     }
 }

--- a/BSWInterfaceKitDemoTests/ColumnFlowLayoutTests.swift
+++ b/BSWInterfaceKitDemoTests/ColumnFlowLayoutTests.swift
@@ -38,6 +38,8 @@ private class ViewController: UIViewController {
         return collectionView.collectionViewLayout as! UICollectionViewFlowLayout
     }
     
+    var dataSource: CollectionViewDataSource<PostCollectionViewCell>!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -51,32 +53,11 @@ private class ViewController: UIViewController {
         
         collectionView.backgroundColor = .clear
         collectionView.alwaysBounceVertical = true
-        collectionView.dataSource = self
-        collectionView.delegate = self
         collectionView.pinToSuperview()
-        collectionView.register(PostCollectionViewCell.self, forCellWithReuseIdentifier: "PostCollectionViewCell")
         collectionView.layoutMargins = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+        dataSource = .init(data: mockData, collectionView: collectionView)
     }
 }
-
-
-@available(iOS 11, *)
-extension ViewController: UICollectionViewDataSource, UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return mockData.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "PostCollectionViewCell", for: indexPath) as! PostCollectionViewCell
-        cell.configureFor(viewModel: self.mockData[indexPath.item])
-        return cell
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
-        print("willDisplay: \(cell)")
-    }
-}
-
 
 @available(iOS 11, *)
 extension ViewController {
@@ -127,7 +108,7 @@ extension ViewController {
 
 import UIKit
 
-private class PostCollectionViewCell: UICollectionViewCell {
+private class PostCollectionViewCell: UICollectionViewCell, ViewModelReusable {
     
     private let imageView = UIImageView()
     

--- a/Source/Cells/FormTableViewCell.swift
+++ b/Source/Cells/FormTableViewCell.swift
@@ -39,12 +39,16 @@ open class FormTableViewCell<InputView: ViewModelConfigurable & UIView>: UITable
         fatalError("init(coder:) has not been implemented")
     }
     
-    public func configureFor(viewModel vm: VM) {
-        warningMessageLabel.attributedText = vm.warningMessage
-        warningMessageLabel.isHidden = (vm.warningMessage == nil)
-        formInputView.configureFor(viewModel: vm.inputVM)
+    public func configureFor(viewModel: FormTableViewCell<InputView>.VM, traitCollection: UITraitCollection) {
+        configureFor(viewModel: viewModel)
+        formInputView.configureFor(viewModel: viewModel.inputVM, traitCollection: traitCollection)
     }
     
+    public func configureFor(viewModel: FormTableViewCell<InputView>.VM) {
+        warningMessageLabel.attributedText = viewModel.warningMessage
+        warningMessageLabel.isHidden = (viewModel.warningMessage == nil)
+    }
+
     private func layout() {
         contentView.addAutolayoutSubview(stackView)
         stackView.pinToSuperview()

--- a/Source/Cells/PhotoCollectionViewCell.swift
+++ b/Source/Cells/PhotoCollectionViewCell.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public class PhotoCollectionViewCell: UICollectionViewCell, ViewModelReusable {
+public class PhotoCollectionViewCell: UICollectionViewCell, ViewModelReusable {    
 
     public let cellImageView: UIImageView = {
         let view = UIImageView()

--- a/Source/Cells/PolaroidCollectionViewCell.swift
+++ b/Source/Cells/PolaroidCollectionViewCell.swift
@@ -26,15 +26,15 @@ open class PolaroidCollectionViewCell: UICollectionViewCell, ViewModelReusable {
         }
     }
 
-    fileprivate let detailSubview = PolaroidCollectionCellBasicInfoView()
+    private let detailSubview = PolaroidCollectionCellBasicInfoView()
     
-    fileprivate let cellImageView: UIImageView = {
+    private let cellImageView: UIImageView = {
         let view = UIImageView()
         view.contentMode = .scaleAspectFill
         view.clipsToBounds = true
         return view
     }()
-    fileprivate let stackView = UIStackView()
+    private let stackView = UIStackView()
 
     public static let MaxImageHeightProportion = CGFloat(2)
 
@@ -47,7 +47,7 @@ open class PolaroidCollectionViewCell: UICollectionViewCell, ViewModelReusable {
         fatalError("init(coder:) has not been implemented")
     }
     
-    fileprivate func setup() {
+    private func setup() {
         stackView.addArrangedSubview(cellImageView)
         stackView.addArrangedSubview(detailSubview)
         stackView.axis = .vertical
@@ -70,9 +70,9 @@ open class PolaroidCollectionViewCell: UICollectionViewCell, ViewModelReusable {
 
     /// This is a placeholder constraint to make sure that when doing the final
     /// layout for the wanted viewModel, the image height is not compressed
-    fileprivate var imageHeightConstraint: NSLayoutConstraint!
+    private var imageHeightConstraint: NSLayoutConstraint!
     
-    fileprivate func setupImageConstraint(multiplier: CGFloat = 1) {
+    private func setupImageConstraint(multiplier: CGFloat = 1) {
         if let imageHeightConstraint = self.imageHeightConstraint {
             cellImageView.removeConstraint(imageHeightConstraint)
         }
@@ -80,12 +80,12 @@ open class PolaroidCollectionViewCell: UICollectionViewCell, ViewModelReusable {
         NSLayoutConstraint.activate([imageHeightConstraint])
     }
     
-    fileprivate func setupRoundedCorners() {
+    private func setupRoundedCorners() {
         contentView.roundCorners()
     }
     
-    open func configureFor(viewModel: VM) {
-
+    public func configureFor(viewModel: VM) {
+        
         //Set the basic info
         detailSubview.setTitle(viewModel.cellTitle, subtitle: viewModel.cellDetails)
 
@@ -105,21 +105,21 @@ open class PolaroidCollectionViewCell: UICollectionViewCell, ViewModelReusable {
 @objc(BSWPolaroidCollectionCellBasicInfoView)
 public class PolaroidCollectionCellBasicInfoView: UIView {
     
-    let titleLabel: UILabel = {
+    private let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 2
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
     
-    let detailLabel: UILabel = {
+    private let detailLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 1
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         return label
     }()
 
-    let stackView: UIStackView = {
+    private let stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.alignment = .fill
@@ -141,7 +141,7 @@ public class PolaroidCollectionCellBasicInfoView: UIView {
         detailLabel.attributedText = subtitle
     }
     
-    fileprivate func setup() {
+    private func setup() {
         backgroundColor = .white
         addAutolayoutSubview(stackView)
         stackView.pinToSuperview()

--- a/Source/DataSource/CollectionViewDataSource.swift
+++ b/Source/DataSource/CollectionViewDataSource.swift
@@ -104,7 +104,7 @@ public class CollectionViewDataSource<Cell:ViewModelReusable & UICollectionViewC
     @objc public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell: Cell = collectionView.dequeueReusableCell(indexPath: indexPath)
         let model = data[indexPath.item]
-        cell.configureFor(viewModel: model)
+        cell.configureFor(viewModel: model, traitCollection: collectionView.traitCollection)
         return cell
     }
     

--- a/Source/Protocols/ViewModel.swift
+++ b/Source/Protocols/ViewModel.swift
@@ -12,11 +12,18 @@ import Deferred
 public protocol ViewModelConfigurable: class {
     associatedtype VM
     func configureFor(viewModel: VM)
+    func configureFor(viewModel: VM, traitCollection: UITraitCollection)
 }
 
 public protocol ViewModelReusable: ViewModelConfigurable {
     static var reuseType: ReuseType { get }
     static var reuseIdentifier: String { get }
+}
+
+public extension ViewModelConfigurable {
+    func configureFor(viewModel: VM, traitCollection: UITraitCollection) {
+        configureFor(viewModel: viewModel)
+    }
 }
 
 public protocol AsyncViewModelPresenter: ViewModelConfigurable {


### PR DESCRIPTION
Cells are not added to the view hierarchy until *after* they are returned from `cellForRow...`. This means that they are not in the view hierarchy (and therefore can't access `traitCollection` information) during the `configureForViewModel:` method.

This new (optional) method will pass the traitCollection information to make sure all adjustments are made in the `configureForViewModel:` phase of the layout
