### PR TITLE
Initialize TextStyler with UIFontDescriptor for better customization

### DIFF
--- a/Sources/BSWInterfaceKit/Stylesheet/TextStyler.swift
+++ b/Sources/BSWInterfaceKit/Stylesheet/TextStyler.swift
@@ -12,11 +12,20 @@ open class TextStyler {
     
     // https://gist.github.com/zacwest/916d31da5d03405809c4
     
-    public static let styler = TextStyler()
-    public init(preferredFontName: String? = nil) {
-        self.preferredFontName = preferredFontName
+    public static let styler = TextStyler(fontDescriptor: nil)
+    
+    convenience init(preferredFontName: String? = nil) {
+        if let fontName = preferredFontName {
+            self.init(fontDescriptor: .init(name: fontName, size: 0))
+        } else {
+            self.init(fontDescriptor: nil)
+        }
     }
-    open var preferredFontName: String?
+    public init(fontDescriptor: UIFontDescriptor? = nil) {
+        self.fontDescriptor = fontDescriptor
+    }
+
+    open var fontDescriptor: UIFontDescriptor?
     open var minContentSizeSupported = UIContentSizeCategory.small
     open var maxContentSizeSupported = UIContentSizeCategory.extraExtraExtraLarge
 
@@ -48,16 +57,14 @@ open class TextStyler {
                 return nil
             }
         }()
-
         let systemFont = UIFont.preferredFont(forTextStyle: style, compatibleWith: traitCollection)
-        guard
-            let preferredFontName = preferredFontName,
-            let font = UIFont(name: preferredFontName, size: systemFont.pointSize) else {
-                return systemFont
+        if let fontDescriptor = fontDescriptor {
+            let font = UIFont.init(descriptor: fontDescriptor, size: systemFont.pointSize)
+            let metrics = UIFontMetrics(forTextStyle: style)
+            return metrics.scaledFont(for: font, compatibleWith: traitCollection)
+        } else {
+            return systemFont
         }
-
-        let metrics = UIFontMetrics(forTextStyle: style)
-        return metrics.scaledFont(for: font, compatibleWith: traitCollection)
     }
 }
 

--- a/Tests/BSWInterfaceKitTests/Suite/TextStylerTests.swift
+++ b/Tests/BSWInterfaceKitTests/Suite/TextStylerTests.swift
@@ -12,7 +12,7 @@ class TextStylerTests: BSWSnapshotTest {
     override func setUp() {
         super.setUp()
         sut = TextStyler()
-        sut.preferredFontName = "ChalkboardSE-Light"
+        sut.fontDescriptor = .init(name: "ChalkboardSE-Light", size: 0)
     }
 
     func testTitle() {
@@ -36,7 +36,7 @@ class TextStylerTests: BSWSnapshotTest {
     }
 
     func testBoldedString() {
-        sut.preferredFontName = nil
+        sut.fontDescriptor = nil
         let string = sut.attributedString("Juventus", color: .black, forStyle: .body).bolded
         verify(attributedString: string)
     }


### PR DESCRIPTION
In order to support better customisation of fonts using "stylistic alternate font" for Videoask, we need to stop using `Strings` as the input for this class and use the better customisation point: `UIFontDescription`