### PR TITLE
Updates to AsyncStateView

### DIFF
--- a/Sources/BSWInterfaceKit/SwiftUI/AsyncStateView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/AsyncStateView.swift
@@ -61,9 +61,9 @@ struct RecipeListView: View, PlaceholderDataProvider {
 public struct AsyncStateView<Data, HostedView: View, ErrorView: View, LoadingView: View>: View {
     
     /// Represents the state of this view
-    enum AsyncState<T> {
+    enum AsyncState {
         case loading
-        case loaded(T)
+        case loaded(Data)
         case error(Swift.Error)
     }
 
@@ -78,7 +78,7 @@ public struct AsyncStateView<Data, HostedView: View, ErrorView: View, LoadingVie
     let hostedViewGenerator: HostedViewGenerator
     let errorViewGenerator: ErrorViewGenerator
     let loadingView: LoadingView
-    @State private var state: AsyncState<Data> = .loading
+    @State private var state: AsyncState = .loading
     
     /// Creates a new `AsyncStateView`
     /// - Parameters:

--- a/Sources/BSWInterfaceKit/SwiftUI/AsyncStateView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/AsyncStateView.swift
@@ -134,7 +134,7 @@ public struct AsyncStateView<Data, HostedView: View, ErrorView: View, LoadingVie
 
     @MainActor
     private func fetchData() async {
-        guard reasons.isEmpty else {
+        if reasons.contains(.placeholder) {
             /// Make sure no request is fired in case that this view
             /// is used to compose a sub-section of the view hierarchy.
             return

--- a/Sources/BSWInterfaceKit/SwiftUI/AsyncStateView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/AsyncStateView.swift
@@ -135,6 +135,8 @@ public struct AsyncStateView<Data, HostedView: View, ErrorView: View, LoadingVie
     @MainActor
     private func fetchData() async {
         guard reasons.isEmpty else {
+            /// Make sure no request is fired in case that this view
+            /// is used to compose a sub-section of the view hierarchy.
             return
         }
         withAnimation {

--- a/Sources/BSWInterfaceKit/SwiftUI/Previews/AsyncStateView+Preview.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Previews/AsyncStateView+Preview.swift
@@ -31,8 +31,7 @@ private struct AsyncContentView: View {
             AsyncStateView(
                 id: asyncViewID,
                 dataGenerator: {
-                    try await Task.sleep(for: .milliseconds(300))
-                    return Self.generateData(forQuery: asyncViewID)
+                    await Self.generateData(forQuery: asyncViewID)
                 },
                 hostedViewGenerator: {
                     ContentView(data: $0)
@@ -41,7 +40,11 @@ private struct AsyncContentView: View {
         }
     }
     
-    static func generateData(forQuery query: String) -> String {
+    static func generateData(forQuery query: String) async -> String {
+        /// On a real app, this method will call a Web Server to fetch
+        /// real data, but here we're mocking what to return in
+        /// depending on the supplied ID. This is just mock logic.
+        try? await Task.sleep(for: .milliseconds(300))
         switch query {
         case "default-value":
             return "Lorem ipsum dolor sit amet, consectetur adipiscing elit."

--- a/Sources/BSWInterfaceKit/SwiftUI/Previews/AsyncStateView+Preview.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Previews/AsyncStateView+Preview.swift
@@ -1,0 +1,70 @@
+
+import SwiftUI
+
+/// Example of how to reload `AsyncStateView`
+/// when the ID of the operation changes.
+
+@available(iOS 16.0, *)
+struct AsyncContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        AsyncContentView()
+    }
+}
+
+@available(iOS 16.0, *)
+private struct AsyncContentView: View {
+    
+    @State var asyncViewID: String = "default-value"
+    
+    var body: some View {
+        
+        VStack {
+            HStack {
+                Button("Swap1") {
+                    asyncViewID = "swap-1"
+                }
+                Button("Swap2") {
+                    asyncViewID = "swap-2"
+                }
+            }
+            Spacer()
+            AsyncStateView(
+                id: asyncViewID,
+                dataGenerator: {
+                    try await Task.sleep(for: .milliseconds(300))
+                    return Self.generateData(forQuery: asyncViewID)
+                },
+                hostedViewGenerator: {
+                    ContentView(data: $0)
+                }
+            )
+        }
+    }
+    
+    static func generateData(forQuery query: String) -> String {
+        switch query {
+        case "default-value":
+            return "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        case "swap-1":
+            return "Etiam pharetra maximus felis ac commodo. Proin tortor ex, ornare quis bibendum sed, mollis nec est"
+        case "swap-2":
+            return "Nam vel nunc ipsum. Nunc in magna sed nisi dapibus feugiat in vel elit"
+        default:
+            return ContentView.generatePlaceholderData()
+        }
+    }
+
+    struct ContentView: View, PlaceholderDataProvider {
+        let data: String
+        
+        var body: some View {
+            Text(data)
+                .font(.largeTitle)
+                .padding()
+        }
+        
+        static func generatePlaceholderData() -> String {
+            "Morbi ullamcorper interdum ex, non feugiat neque hendrerit eu."
+        }
+    }
+}


### PR DESCRIPTION
- Fix issue where if the `id` changed during a `.loading` state, the view wouldn't update to reflect this.
- Make sure no request is fired in case that `AsyncStateView` is used to compose a sub-section of the view hierarchy.
- Remove the `Binding<String>` initialiser since the `AsyncStateView` never mutated this value.