### PR TITLE
More fixes on AsyncStateView

### DIFF
--- a/Sources/BSWInterfaceKit/SwiftUI/Previews/AsyncStateView+Preview.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Previews/AsyncStateView+Preview.swift
@@ -31,7 +31,7 @@ private struct AsyncContentView: View {
             AsyncStateView(
                 id: asyncViewID,
                 dataGenerator: {
-                    await Self.generateData(forQuery: asyncViewID)
+                    await generateData(forQuery: asyncViewID)
                 },
                 hostedViewGenerator: {
                     ContentView(data: $0)
@@ -39,8 +39,8 @@ private struct AsyncContentView: View {
             )
         }
     }
-    
-    static func generateData(forQuery query: String) async -> String {
+
+    func generateData(forQuery query: String) async -> String {
         /// On a real app, this method will call a Web Server to fetch
         /// real data, but here we're mocking what to return in
         /// depending on the supplied ID. This is just mock logic.
@@ -53,7 +53,7 @@ private struct AsyncContentView: View {
         case "swap-2":
             return "Nam vel nunc ipsum. Nunc in magna sed nisi dapibus feugiat in vel elit"
         default:
-            return ContentView.generatePlaceholderData()
+            return AsyncContentView.ContentView.generatePlaceholderData()
         }
     }
 


### PR DESCRIPTION
From `.task(id:)` documentation:

> Adds a task to perform before this view appears **or** when a specified value changes.

This means that the block was being called when the view reappeared on screen, triggering another fetch.

Finally, the solution is to drop `@State` and move to `@ObservedObject` instead, which will keep the user's state in a class which we have more control over.