### PR TITLE
Use ViewModifier instead of View for errorAlert

### DIFF
--- a/Sources/BSWInterfaceKit/SwiftUI/Extensions/SwiftUI+View.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Extensions/SwiftUI+View.swift
@@ -15,42 +15,42 @@ public extension SwiftUI.View {
 
 #endif
 
+import SwiftUI
+
 public extension View {
     func errorAlert(error: Binding<Error?>) -> some View {
-        ErrorAwareView(errorBinding: error, content: self)
+      modifier(ErrorAwareView(errorBinding: error))
     }
 }
 
-private struct ErrorAwareView<T: View>: View {
+private struct ErrorAwareView: ViewModifier {
     
-    let errorBinding: Binding<Error?>
-    let content: T
-
-    var body: some View {
-        content
-            .alert(
-                "error".localized,
-                isPresented: .init(get: {
-                    errorBinding.wrappedValue != nil
-                }, set: { value in
-                    if value == false {
-                        withAnimation {
-                            errorBinding.wrappedValue = nil
-                        }
-                    }
-                }),
-                presenting: errorBinding.wrappedValue,
-                actions: { error in
-                    Button("dismiss".localized, action: { })
-                }, message: {
-                    if let localizedError = $0 as? LocalizedError,
-                       let failureReason = localizedError.errorDescription {
-                        Text(failureReason)
-                    } else {
-                        Text("Something went wrong")
-                    }
-                }
-            )
-    }
-    
+  let errorBinding: Binding<Error?>
+  
+  func body(content: Content) -> some View {
+    content
+      .alert(
+        "error".localized,
+        isPresented: .init(get: {
+          errorBinding.wrappedValue != nil
+        }, set: { value in
+          if value == false {
+            withAnimation {
+              errorBinding.wrappedValue = nil
+            }
+          }
+        }),
+        presenting: errorBinding.wrappedValue,
+        actions: { error in
+          Button("dismiss".localized, action: { })
+        }, message: {
+          if let localizedError = $0 as? LocalizedError,
+             let failureReason = localizedError.errorDescription {
+            Text(failureReason)
+          } else {
+            Text("Something went wrong")
+          }
+        }
+      )
+  }
 }


### PR DESCRIPTION
`errorAlert` extension of `SwiftUI.View` was defined as a plain view. Let's define it as a `ViewModifier` instead.