### PR TITLE
PhotoView remove background

### DIFF
--- a/.github/workflows/buildEmerge.yml
+++ b/.github/workflows/buildEmerge.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build XCFramework
-    runs-on: ios
+    runs-on: mobile
     env:
       PRODUCT_NAME: BSWInterfaceKit
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,13 +6,13 @@ on:
 jobs:
   build:
 
-    runs-on: ios
+    runs-on: mobile
 
     steps:
     - uses: actions/checkout@v4
       with:
         lfs: true
     - name: Test BSWInterfaceKit iOS
-      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 16,OS=18.2" test | xcbeautify --renderer github-actions
+      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 16,OS=18.3.1" test | xcbeautify --renderer github-actions
     - name: Build BSWInterfaceKit macOS
       run: set -o pipefail && swift build | xcbeautify --renderer github-actions

--- a/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
@@ -4,9 +4,19 @@
 
 import SwiftUI
 import NukeUI; import Nuke
-import Vision
-import CoreImage
-import CoreImage.CIFilterBuiltins
+
+#Preview {
+    PhotoView(
+        photo: .init(url: URL(string: "https://static.nike.com/a/images/t_PDP_1728_v1/f_auto,q_auto:eco/b7d9211c-26e7-431a-ac24-b0540fb3c00f/AIR+FORCE+1+%2707.png")),
+        configuration: .init(
+            placeholder: .init(shape: .rectangle),
+            aspectRatio: nil,
+            contentMode: .fit,
+            shouldRemoveBackground: false
+        )
+    )
+    .frame(width: 300)
+}
 
 /// Displays a `Photo` in `SwiftUI`
 public struct PhotoView: View {
@@ -21,14 +31,17 @@ public struct PhotoView: View {
     @Environment(\.redactionReasons) var reasons: RedactionReasons
     
     public var body: some View {
-        Group {
-            if shouldShowPlaceholder {
-                placeholder
-            } else {
-                photoView
-            }
+        contentView
+            .aspectRatio(configuration.aspectRatio, contentMode: configuration.contentMode)
+    }
+    
+    @ViewBuilder
+    private var contentView: some View {
+        if shouldShowPlaceholder {
+            placeholder
+        } else {
+            photoView
         }
-        .aspectRatio(configuration.aspectRatio, contentMode: configuration.contentMode)
     }
     
     private var shouldShowPlaceholder: Bool {
@@ -52,17 +65,12 @@ public struct PhotoView: View {
         switch photo.kind {
         case .url(let url, _):
             LazyImage(url: url, transaction: .init(animation: .default)) { state in
-                if #available(iOS 17.0, *),
-                   configuration.shouldRemoveBackground,
-                   let uiImage = state.imageContainer?.extractSubject() {
-                    Image(uiImage: uiImage)
-                        .resizable()
-                }
-                else if let image = state.image {
+                if #available(iOS 17.0, *), configuration.shouldRemoveBackground, let uiImage = state.imageContainer?.image {
+                    RemoveBackgroundView(image: uiImage, placeholder: configuration.placeholder)
+                } else if let image = state.image {
                     image
                         .resizable()
-                }
-                else {
+                } else {
                     placeholder
                 }
             }
@@ -84,6 +92,29 @@ public struct PhotoView: View {
         #else
         false
         #endif
+    }
+    
+    @available(iOS 17, *)
+    struct RemoveBackgroundView: View {
+        
+        let image: UIImage
+        let placeholder: PhotoView.Configuration.Placeholder
+        
+        @State var decodedImage: UIImage?
+        
+        var body: some View {
+            Group {
+                if let decodedImage {
+                    Image(uiImage: decodedImage)
+                        .resizable()
+                } else {
+                    placeholder.body()
+                }
+            }
+            .task {
+                self.decodedImage = image.extractSubject()
+            }
+        }
     }
 }
 
@@ -131,11 +162,20 @@ extension PhotoView {
     }
 }
 
+import Vision
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
 @available(iOS 17.0, *)
-private extension ImageContainer {
+private extension UIImage {
     
-    func extractSubject() -> UIImage? {
-        guard let inputImage = CIImage(image: self.image) else { return nil }
+#if targetEnvironment(simulator)
+    nonisolated func extractSubject() -> UIImage? {
+        self
+    }
+#else
+    nonisolated func extractSubject() -> UIImage? {
+        guard let inputImage = CIImage(image: self) else { return nil }
         let request = VNGenerateForegroundInstanceMaskRequest()
         let handler = VNImageRequestHandler(ciImage: inputImage)
         
@@ -163,4 +203,5 @@ private extension ImageContainer {
             return nil
         }
     }
+  #endif
 }

--- a/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
@@ -65,6 +65,7 @@ public struct PhotoView: View {
         switch photo.kind {
         case .url(let url, _):
             LazyImage(url: url, transaction: .init(animation: .default)) { state in
+                #if canImport(UIKit)
                 if #available(iOS 17.0, *), configuration.shouldRemoveBackground, let uiImage = state.imageContainer?.image {
                     RemoveBackgroundView(image: uiImage, placeholder: configuration.placeholder)
                 } else if let image = state.image {
@@ -73,6 +74,14 @@ public struct PhotoView: View {
                 } else {
                     placeholder
                 }
+                #else
+                if let image = state.image {
+                    image
+                        .resizable()
+                } else {
+                    placeholder
+                }
+                #endif
             }
         case .image(let image):
             #if canImport(UIKit)
@@ -93,6 +102,10 @@ public struct PhotoView: View {
         false
         #endif
     }
+}
+
+#if canImport(UIKit)
+private extension PhotoView {
     
     @available(iOS 17, *)
     struct RemoveBackgroundView: View {
@@ -117,6 +130,51 @@ public struct PhotoView: View {
         }
     }
 }
+
+import Vision
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+@available(iOS 17.0, *)
+private extension UIImage {
+    
+    #if targetEnvironment(simulator)
+    nonisolated func extractSubject() async -> UIImage? {
+        self
+    }
+    #else
+    nonisolated func extractSubject() async -> UIImage? {
+        guard let inputImage = CIImage(image: self) else { return nil }
+        let request = VNGenerateForegroundInstanceMaskRequest()
+        let handler = VNImageRequestHandler(ciImage: inputImage)
+        
+        do {
+            try handler.perform([request])
+            guard let result = request.results?.first,
+                  let mask = try? result.generateScaledMaskForImage(
+                    forInstances: result.allInstances,
+                    from: handler
+                  ) else {
+                return nil
+            }
+            let maskImage = CIImage(cvPixelBuffer: mask)
+            let filter = CIFilter.blendWithMask()
+            filter.inputImage = inputImage
+            filter.maskImage = maskImage
+            filter.backgroundImage = CIImage.empty()
+            
+            guard let outputImage = filter.outputImage,
+                  let cgImage = CIContext(options: nil).createCGImage(outputImage, from: outputImage.extent)
+            else { return nil }
+            
+            return UIImage(cgImage: cgImage)
+        } catch {
+            return nil
+        }
+    }
+    #endif
+}
+#endif
 
 extension PhotoView {
         
@@ -160,48 +218,4 @@ extension PhotoView {
             }
         }
     }
-}
-
-import Vision
-import CoreImage
-import CoreImage.CIFilterBuiltins
-
-@available(iOS 17.0, *)
-private extension UIImage {
-    
-#if targetEnvironment(simulator)
-    nonisolated func extractSubject() async -> UIImage? {
-        self
-    }
-#else
-    nonisolated func extractSubject() async -> UIImage? {
-        guard let inputImage = CIImage(image: self) else { return nil }
-        let request = VNGenerateForegroundInstanceMaskRequest()
-        let handler = VNImageRequestHandler(ciImage: inputImage)
-        
-        do {
-            try handler.perform([request])
-            guard let result = request.results?.first,
-                  let mask = try? result.generateScaledMaskForImage(
-                    forInstances: result.allInstances,
-                    from: handler
-                  ) else {
-                return nil
-            }
-            let maskImage = CIImage(cvPixelBuffer: mask)
-            let filter = CIFilter.blendWithMask()
-            filter.inputImage = inputImage
-            filter.maskImage = maskImage
-            filter.backgroundImage = CIImage.empty()
-            
-            guard let outputImage = filter.outputImage,
-                  let cgImage = CIContext(options: nil).createCGImage(outputImage, from: outputImage.extent)
-            else { return nil }
-            
-            return UIImage(cgImage: cgImage)
-        } catch {
-            return nil
-        }
-    }
-  #endif
 }

--- a/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
@@ -3,7 +3,10 @@
 //
 
 import SwiftUI
-import NukeUI
+import NukeUI; import Nuke
+import Vision
+import CoreImage
+import CoreImage.CIFilterBuiltins
 
 /// Displays a `Photo` in `SwiftUI`
 public struct PhotoView: View {
@@ -49,10 +52,17 @@ public struct PhotoView: View {
         switch photo.kind {
         case .url(let url, _):
             LazyImage(url: url, transaction: .init(animation: .default)) { state in
-                if let image = state.image {
+                if #available(iOS 17.0, *),
+                   configuration.shouldRemoveBackground,
+                   let uiImage = state.imageContainer?.extractSubject() {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                }
+                else if let image = state.image {
                     image
                         .resizable()
-                } else {
+                }
+                else {
                     placeholder
                 }
             }
@@ -83,11 +93,13 @@ extension PhotoView {
         let placeholder: Placeholder
         let aspectRatio: CGFloat?
         let contentMode: ContentMode
+        let shouldRemoveBackground: Bool
         
-        public init(placeholder: Placeholder = .init(shape: .rectangle), aspectRatio: CGFloat? = nil, contentMode: ContentMode = .fit) {
+        public init(placeholder: Placeholder = .init(shape: .rectangle), aspectRatio: CGFloat? = nil, contentMode: ContentMode = .fit, shouldRemoveBackground: Bool = false) {
             self.placeholder = placeholder
             self.aspectRatio = aspectRatio
             self.contentMode = contentMode
+            self.shouldRemoveBackground = shouldRemoveBackground
         }
         
         public struct Placeholder: Sendable {
@@ -115,6 +127,40 @@ extension PhotoView {
                 }
                 .foregroundColor(color)
             }
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+private extension ImageContainer {
+    
+    func extractSubject() -> UIImage? {
+        guard let inputImage = CIImage(image: self.image) else { return nil }
+        let request = VNGenerateForegroundInstanceMaskRequest()
+        let handler = VNImageRequestHandler(ciImage: inputImage)
+        
+        do {
+            try handler.perform([request])
+            guard let result = request.results?.first,
+                  let mask = try? result.generateScaledMaskForImage(
+                    forInstances: result.allInstances,
+                    from: handler
+                  ) else {
+                return nil
+            }
+            let maskImage = CIImage(cvPixelBuffer: mask)
+            let filter = CIFilter.blendWithMask()
+            filter.inputImage = inputImage
+            filter.maskImage = maskImage
+            filter.backgroundImage = CIImage.empty()
+            
+            guard let outputImage = filter.outputImage,
+                  let cgImage = CIContext(options: nil).createCGImage(outputImage, from: outputImage.extent)
+            else { return nil }
+            
+            return UIImage(cgImage: cgImage)
+        } catch {
+            return nil
         }
     }
 }

--- a/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
@@ -112,7 +112,7 @@ public struct PhotoView: View {
                 }
             }
             .task {
-                self.decodedImage = image.extractSubject()
+                self.decodedImage = await image.extractSubject()
             }
         }
     }
@@ -170,11 +170,11 @@ import CoreImage.CIFilterBuiltins
 private extension UIImage {
     
 #if targetEnvironment(simulator)
-    nonisolated func extractSubject() -> UIImage? {
+    nonisolated func extractSubject() async -> UIImage? {
         self
     }
 #else
-    nonisolated func extractSubject() -> UIImage? {
+    nonisolated func extractSubject() async -> UIImage? {
         guard let inputImage = CIImage(image: self) else { return nil }
         let request = VNGenerateForegroundInstanceMaskRequest()
         let handler = VNImageRequestHandler(ciImage: inputImage)


### PR DESCRIPTION
We’ve been trying to implement this in the Naturitas app for some time.

Product images always had a white background, which made the dark mode experience quite poor. With this solution, we remove the background after downloading the image, ensuring a more polished and premium look, worthy of the best app on the market.
<img width="1035" alt="Screenshot 2025-02-26 at 16 05 45" src="https://github.com/user-attachments/assets/7d2c2f2a-fdce-4181-94cb-88aa1d376c68" />

https://github.com/user-attachments/assets/3b2ccc4e-b859-4c66-a676-e72cc08bc4fb


