### PR TITLE
Gracefully fallback to original image if background removal fails

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         lfs: true
     - name: Test BSWInterfaceKit iOS
-      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 16,OS=18.4" test | xcbeautify --renderer github-actions
+      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5" test | xcbeautify --renderer github-actions
   
   macos-build:
     runs-on: mobile

--- a/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Views/PhotoView.swift
@@ -185,8 +185,8 @@ private extension UIImage {
         self
     }
     #else
-    nonisolated func extractSubject() async -> UIImage? {
-        guard let inputImage = CIImage(image: self) else { return nil }
+    nonisolated func extractSubject() async -> UIImage {
+        guard let inputImage = CIImage(image: self) else { return self }
         let request = VNGenerateForegroundInstanceMaskRequest()
         let handler = VNImageRequestHandler(ciImage: inputImage)
         
@@ -197,7 +197,7 @@ private extension UIImage {
                     forInstances: result.allInstances,
                     from: handler
                   ) else {
-                return nil
+                return self
             }
             let maskImage = CIImage(cvPixelBuffer: mask)
             let filter = CIFilter.blendWithMask()
@@ -207,11 +207,11 @@ private extension UIImage {
             
             guard let outputImage = filter.outputImage,
                   let cgImage = CIContext(options: nil).createCGImage(outputImage, from: outputImage.extent)
-            else { return nil }
+            else { return self }
             
             return UIImage(cgImage: cgImage)
         } catch {
-            return nil
+            return self
         }
     }
     #endif


### PR DESCRIPTION
- `extractSubject()` no longer crashes when Vision fails to generate a mask.
- If background removal fails, the original image is displayed as fallback.


![IMG_9137E650CF43-1](https://github.com/user-attachments/assets/93eac392-d905-48fd-95a8-602d81221c02)
