### PR TITLE
BottomContainer content pinned to keyboardLayoutGuide.topAnchor

### DIFF
--- a/Sources/BSWInterfaceKit/Extensions/UIViewController+Utilities.swift
+++ b/Sources/BSWInterfaceKit/Extensions/UIViewController+Utilities.swift
@@ -149,6 +149,21 @@ public extension UIViewController {
     }
 }
 
+public extension UIViewController {
+    
+    func addEdgeElementContainerInteraction(for scrollView: UIScrollView) {
+        #if swift(>=6.2)
+        if #available(iOS 26.0, *) {
+            let interaction = UIScrollEdgeElementContainerInteraction()
+            interaction.scrollView = scrollView
+            interaction.edge = .bottom
+            self.view.backgroundColor = nil
+            self.view.addInteraction(interaction)
+        }
+        #endif
+    }
+}
+
 // MARK: Private
 
 private let alertQueue: OperationQueue = {

--- a/Sources/BSWInterfaceKit/ViewControllers/BottomContainerViewController.swift
+++ b/Sources/BSWInterfaceKit/ViewControllers/BottomContainerViewController.swift
@@ -88,7 +88,13 @@ open class BottomContainerViewController: UIViewController {
             if isiOSAppOnMac() {
                 return containedViewController.view.bottomAnchor.constraint(equalTo: buttonContainer.view.topAnchor)
             } else {
-                return containedViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                let k = view.keyboardLayoutGuide
+                if #available(iOS 17.0, *) {
+                    /// Needed to preserve the real bottom edge for
+                    /// `UIScrollEdgeElementContainerInteraction`.
+                    k.usesBottomSafeArea = false
+                }
+                return containedViewController.view.bottomAnchor.constraint(equalTo: k.topAnchor)
             }
         }()
         NSLayoutConstraint.activate([

--- a/Sources/BSWInterfaceKit/ViewControllers/BottomContainerViewController.swift
+++ b/Sources/BSWInterfaceKit/ViewControllers/BottomContainerViewController.swift
@@ -103,15 +103,10 @@ open class BottomContainerViewController: UIViewController {
         containedViewController.didMove(toParent: self)
         buttonContainer.didMove(toParent: self)
         
-        #if swift(>=6.2)
-        if #available(iOS 26.0, *), shouldAdoptGlassInterface, let scrollView = containedViewController.findFirstScrollView() {
-            let interaction = UIScrollEdgeElementContainerInteraction()
-            interaction.scrollView = scrollView
-            interaction.edge = .bottom
-            buttonContainer.view.backgroundColor = nil
-            buttonContainer.view.addInteraction(interaction)
+        if shouldAdoptGlassInterface,
+           let scrollView = containedViewController.findFirstScrollView() {
+            buttonContainer.addEdgeElementContainerInteraction(for: scrollView)
         }
-        #endif
     }
     
     open override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Since iOS 17, `UIKeyboardLayoutGuide` defaults to aligning its top anchor with the safe area bottom when the keyboard is hidden. By setting `usesBottomSafeArea = false`, we force the guide to align with the actual `view.bottomAnchor` instead of the safe area. This ensures the scroll view still reaches the physical bottom of the screen, which is required for `UIScrollEdgeElementContainerInteraction` to detect the bottom edge correctly when using a bottom overlay.