### PR TITLE
BottomContainer content pinned to keyboardLayoutGuide.topAnchor

### DIFF
--- a/Sources/BSWInterfaceKit/ViewControllers/BottomContainerViewController.swift
+++ b/Sources/BSWInterfaceKit/ViewControllers/BottomContainerViewController.swift
@@ -88,7 +88,13 @@ open class BottomContainerViewController: UIViewController {
             if isiOSAppOnMac() {
                 return containedViewController.view.bottomAnchor.constraint(equalTo: buttonContainer.view.topAnchor)
             } else {
-                return containedViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                let k = view.keyboardLayoutGuide
+                if #available(iOS 17.0, *) {
+                    /// Needed to preserve the real bottom edge for
+                    /// `UIScrollEdgeElementContainerInteraction`.
+                    k.usesBottomSafeArea = false
+                }
+                return containedViewController.view.bottomAnchor.constraint(equalTo: k.topAnchor)
             }
         }()
         NSLayoutConstraint.activate([


### PR DESCRIPTION
Since iOS 17, `UIKeyboardLayoutGuide` defaults to aligning its top anchor with the safe area bottom when the keyboard is hidden. By setting `usesBottomSafeArea = false`, we force the guide to align with the actual `view.bottomAnchor` instead of the safe area.  This ensures the scroll view still reaches the physical bottom of the screen, which is required for `UIScrollEdgeElementContainerInteraction` to detect the bottom edge correctly when using a bottom overlay.