### PR TITLE
refactor: update InfiniteScrollingDataSource and preview

### DIFF
--- a/Sources/BSWInterfaceKit/SwiftUI/DataSource/InfiniteScrollingDataSource.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/DataSource/InfiniteScrollingDataSource.swift
@@ -22,11 +22,27 @@ open class InfiniteScrollingDataSource<ListItem: Identifiable & Sendable> {
     
     public typealias ItemFetcher = (Int) async throws -> ([ListItem], Bool)
     
-    public init(currentPage: Int = 0, itemFetcher: @escaping ItemFetcher) async throws {
+    // SKIP @nobridge
+    public init(
+        currentPage: Int = 0,
+        itemFetcher: @escaping ItemFetcher
+    ) async throws {
         self.itemFetcher = itemFetcher
         self.state = State.canLoadMorePages(currentPage: currentPage)
         try await loadMoreContent()
     }
+    
+    #if os(Android)
+    public static func create(
+        currentPage: Int = 0,
+        itemFetcher: @escaping ItemFetcher
+    ) async throws -> InfiniteScrollingDataSource {
+        return try await InfiniteScrollingDataSource(
+            currentPage: currentPage,
+            itemFetcher: itemFetcher
+        )
+    }
+    #endif
     
     public init(mockItems: [ListItem]) {
         self.items = mockItems

--- a/Sources/BSWInterfaceKit/SwiftUI/DataSource/InfiniteScrollingDataSource.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/DataSource/InfiniteScrollingDataSource.swift
@@ -1,16 +1,17 @@
-#if canImport(Darwin)
 
 import SwiftUI
-import Combine
+import Observation
 
 /// As of iOS 18 and aligned releases, this is no longer recommended as
 /// there are cleaner alternatives like `InfiniteVerticalScrollView`
 @MainActor
-open class InfiniteScrollingDataSource<ListItem: Identifiable & Sendable>: ObservableObject {
+@Observable
+open class InfiniteScrollingDataSource<ListItem: Identifiable & Sendable> {
     
-    @Published public private(set) var items = [ListItem]()
-    @Published public private(set) var state: State
-    @Published public var paginationError: Error?
+    public private(set) var items = [ListItem]()
+    public private(set) var state: State
+    public var paginationError: Error?
+    @ObservationIgnored
     private var itemFetcher: ItemFetcher
     
     public enum State: Equatable {
@@ -106,5 +107,3 @@ open class InfiniteScrollingDataSource<ListItem: Identifiable & Sendable>: Obser
         }
     }
 }
-
-#endif

--- a/Sources/BSWInterfaceKit/SwiftUI/DataSource/InfiniteScrollingDataSource.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/DataSource/InfiniteScrollingDataSource.swift
@@ -22,27 +22,11 @@ open class InfiniteScrollingDataSource<ListItem: Identifiable & Sendable> {
     
     public typealias ItemFetcher = (Int) async throws -> ([ListItem], Bool)
     
-    // SKIP @nobridge
-    public init(
-        currentPage: Int = 0,
-        itemFetcher: @escaping ItemFetcher
-    ) async throws {
+    public init(currentPage: Int = 0, itemFetcher: @escaping ItemFetcher) async throws {
         self.itemFetcher = itemFetcher
         self.state = State.canLoadMorePages(currentPage: currentPage)
         try await loadMoreContent()
     }
-    
-    #if os(Android)
-    public static func create(
-        currentPage: Int = 0,
-        itemFetcher: @escaping ItemFetcher
-    ) async throws -> InfiniteScrollingDataSource {
-        return try await InfiniteScrollingDataSource(
-            currentPage: currentPage,
-            itemFetcher: itemFetcher
-        )
-    }
-    #endif
     
     public init(mockItems: [ListItem]) {
         self.items = mockItems

--- a/Sources/BSWInterfaceKit/SwiftUI/Previews/InfiniteScrollingDataSource+Preview.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Previews/InfiniteScrollingDataSource+Preview.swift
@@ -48,7 +48,7 @@ struct InfiniteDataSource_Previews: PreviewProvider {
 
     struct ItemListView: View {
 
-        @StateObject var dataSource: ItemInfiniteDataSource
+        var dataSource: ItemInfiniteDataSource
 
         var body: some View {
             List {
@@ -67,7 +67,7 @@ struct InfiniteDataSource_Previews: PreviewProvider {
 
         struct FooterView: View {
 
-            @ObservedObject var dataSource: ItemInfiniteDataSource
+            var dataSource: ItemInfiniteDataSource
 
             var body: some View {
                 HStack(spacing: 8) {


### PR DESCRIPTION
Remove Combine and replace @Published with SwiftUI's @Observable annotations for better performance with SwiftUI 18. Utilize the @ObservationIgnored attribute for non-observable properties. Simplify preview code by removing unnecessary @StateObject and @ObservedObject wrappers, as the @Observable protocol already manages state changes efficiently.