### PR TITLE
feat: add cross-platform BottomActionBar and TopActionBar components

### DIFF
--- a/Sources/BSWInterfaceKit/SwiftUI/Extensions/BottomActionBar.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/Extensions/BottomActionBar.swift
@@ -1,0 +1,227 @@
+#if os(Android)
+import SkipFuseUI
+#else
+import SwiftUI
+#endif
+
+#if os(Android)
+#if SKIP
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+#endif
+#endif
+
+#if canImport(Darwin)
+
+#Preview("Top Button") {
+    NavigationStack {
+        let fruits = [
+            "Apple", "Banana", "Cherry", "Date", "Elderberry",
+            "Fig", "Grape", "Honeydew", "Kiwi", "Lemon",
+            "Mango", "Nectarine", "Orange", "Papaya", "Quince",
+            "Raspberry", "Strawberry", "Tangerine", "Ugli Fruit", "Watermelon"
+        ]
+        List(fruits, id: \.self, rowContent: Text.init)
+            .topActionBar {
+                AsyncButton(
+                    action: { try await Task.sleep(for: .seconds(1)) },
+                    label: {
+                        HStack { Spacer(); Text("Hello"); Spacer() }
+                    }
+                )
+            }
+    }
+}
+
+#Preview("Bottom Button") {
+    NavigationStack {
+        let fruits = [
+            "Apple", "Banana", "Cherry", "Date", "Elderberry",
+            "Fig", "Grape", "Honeydew", "Kiwi", "Lemon",
+            "Mango", "Nectarine", "Orange", "Papaya", "Quince",
+            "Raspberry", "Strawberry", "Tangerine", "Ugli Fruit", "Watermelon"
+        ]
+        List(fruits, id: \.self, rowContent: Text.init)
+            .bottomActionBar {
+                AsyncButton(
+                    action: { try await Task.sleep(for: .seconds(1)) },
+                    label: {
+                        HStack { Spacer(); Text("Hello"); Spacer() }
+                    }
+                )
+            }
+    }
+}
+#endif
+
+public extension View {
+    
+    @ViewBuilder
+    func bottomActionBar<T: View>(
+        @ViewBuilder button: () -> T
+    ) -> some View {
+        let actionButton = button()
+
+        #if os(Android)
+        ComposeView {
+            AndroidActionBarScaffold(
+                content: self,
+                actionBar: actionButton,
+                isTopBar: false
+            )
+        }
+        #else
+        self.bottomActionBarInset(actionButton)
+        #endif
+    }
+
+    @ViewBuilder
+    func topActionBar<T: View>(
+        @ViewBuilder topBar: () -> T
+    ) -> some View {
+        let actionTopBar = topBar()
+
+        #if os(Android)
+        ComposeView {
+            AndroidActionBarScaffold(
+                content: self,
+                actionBar: actionTopBar,
+                isTopBar: true
+            )
+        }
+        #else
+        self.topActionBarInset(actionTopBar)
+        #endif
+    }
+}
+
+#if os(iOS)
+private extension View {
+
+    @ViewBuilder
+    func bottomActionBarInset<T: View>(_ actionButton: T) -> some View {
+        self.actionBarInset(
+            actionButton,
+            edge: .bottom,
+            dividerAlignment: .top
+        )
+    }
+
+    @ViewBuilder
+    func topActionBarInset<T: View>(_ actionTopBar: T) -> some View {
+        self.actionBarInset(
+            actionTopBar,
+            edge: .top,
+            dividerAlignment: .bottom
+        )
+    }
+
+    @ViewBuilder
+    func actionBarInset<T: View>(
+        _ actionBar: T,
+        edge: VerticalEdge,
+        dividerAlignment: Alignment
+    ) -> some View {
+        if #available(iOS 26.0, macOS 26.0, *) {
+            self.safeAreaBar(edge: edge) {
+                actionBar
+            }
+        } else {
+            self.safeAreaInset(edge: edge) {
+                actionBar
+                    .background(.regularMaterial)
+                    .overlay(alignment: dividerAlignment) {
+                        Divider()
+                    }
+            }
+        }
+    }
+}
+#endif
+
+#if os(Android)
+#if SKIP
+
+struct AndroidActionBarScaffold: ContentComposer {
+    typealias BridgedView = any View
+    let content: BridgedView
+    let actionBar: BridgedView
+    let isTopBar: Bool
+
+    @Composable
+    func Compose(context: ComposeContext) {
+        ComposeContainer(modifier: context.modifier, fillWidth: true, fillHeight: true) { modifier in
+            Scaffold(
+                modifier: modifier.fillMaxSize(),
+                contentWindowInsets: WindowInsets(0),
+                topBar: {
+                    if isTopBar {
+                        Surface(color: MaterialTheme.colorScheme.surface) {
+                            Column(
+                                modifier: Modifier
+                                    .fillMaxWidth()
+                            ) {
+                                actionBar.Compose(
+                                    context: context.content(
+                                        modifier: Modifier.fillMaxWidth()
+                                    )
+                                )
+                                Divider()
+                            }
+                        }
+                    }
+                },
+                bottomBar: {
+                    if !isTopBar {
+                        Surface(color: MaterialTheme.colorScheme.surface) {
+                            Box(
+                                modifier: Modifier
+                                    .fillMaxWidth()
+                                    .imePadding()
+                            ) {
+                                Divider()
+                                Box(
+                                    modifier: Modifier
+                                        .fillMaxWidth()
+                                ) {
+                                    actionBar.Compose(
+                                        context: context.content(
+                                            modifier: Modifier.fillMaxWidth()
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
+                },
+                content: { innerPadding in
+                    Box(
+                        modifier: Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                    ) {
+                        content.Compose(
+                            context: context.content(
+                                modifier: Modifier.fillMaxSize()
+                            )
+                        )
+                    }
+                }
+            )
+        }
+    }
+}
+
+#endif
+#endif

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/ActionBar.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/ActionBar.swift
@@ -114,6 +114,7 @@ public extension View {
     }
 }
 
+#if os(iOS) || os(macOS)
 private extension View {
 
     @ViewBuilder
@@ -137,6 +138,7 @@ private extension View {
         }
     }
 }
+#endif
 
 #if os(Android)
 #if SKIP

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/ActionBar.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/ActionBar.swift
@@ -82,7 +82,11 @@ public extension View {
             )
         }
         #else
-        self.bottomActionBarInset(actionButton)
+        self.actionBarInset(
+            actionButton,
+            edge: .bottom,
+            dividerAlignment: .top
+        )
         #endif
     }
 
@@ -101,31 +105,16 @@ public extension View {
             )
         }
         #else
-        self.topActionBarInset(actionTopBar)
-        #endif
-    }
-}
-
-#if os(iOS)
-private extension View {
-
-    @ViewBuilder
-    func bottomActionBarInset<T: View>(_ actionButton: T) -> some View {
-        self.actionBarInset(
-            actionButton,
-            edge: .bottom,
-            dividerAlignment: .top
-        )
-    }
-
-    @ViewBuilder
-    func topActionBarInset<T: View>(_ actionTopBar: T) -> some View {
         self.actionBarInset(
             actionTopBar,
             edge: .top,
             dividerAlignment: .bottom
         )
+        #endif
     }
+}
+
+private extension View {
 
     @ViewBuilder
     func actionBarInset<T: View>(
@@ -148,7 +137,6 @@ private extension View {
         }
     }
 }
-#endif
 
 #if os(Android)
 #if SKIP


### PR DESCRIPTION
## ✨ Add cross-platform `bottomActionBar` and `topActionBar`

This PR introduces cross-platform `bottomActionBar` and `topActionBar` extensions for `SwiftUI.View`.

These components allow adding action bars at the top or bottom of a view in a clean and reusable way, with platform-specific implementations for iOS and Android.

---

## 🧩 Implementation Details

### iOS
- Uses native SwiftUI view modifiers.
- Overlays buttons using safe area insets.
- Fully native SwiftUI behavior.

### Android
- Uses Compose UI components.
- Integrates action bars at the appropriate layout positions.
- Maintains platform consistency while preserving shared API usage.

---

## 🔍 Previews

Previews have been added for both **Top Button** and **Bottom Button** configurations to demonstrate usage in SwiftUI previews.

This enhancement improves UI consistency and cross-platform interoperability.

---

## 🚀 API Usage Examples

### Bottom Action Bar

```swift
.bottomActionBar {
    AsyncButton("Continue") {
        try await Task.sleep(for: .seconds(1))
    }
}
```

### Top Action Bar

```swift
.topActionBar {
    AsyncButton("Continue") {
        try await Task.sleep(for: .seconds(1))
    }
}
```

---

# 📱 Top Bar Comparison

| iOS | Android |
|-----|----------|
| <img width="250" src="https://github.com/user-attachments/assets/543051dd-cb0f-49a8-90f4-9dc81a38c889" /> | <img width="250" src="https://github.com/user-attachments/assets/4b8865f6-4aef-4039-b81c-610d9ae85341" /> |

---

# 📱 Bottom Bar Comparison

| iOS | Android |
|-----|----------|
| <img width="250" src="https://github.com/user-attachments/assets/4774ec75-c483-4307-bd10-43f0efcb00b3" /> | <img width="250" src="https://github.com/user-attachments/assets/0c6cf31e-b08e-4fd1-b0be-e9b5cfea296f" /> |

