### PR TITLE
Improve intrinsic height sheet

### DIFF
--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -67,6 +67,14 @@ struct IntrinsicHeightDetentView_ForBool<Host: View, Content: View>: View {
 
     var body: some View {
         hostView
+        .onChange(of: isPresented) { _, newValue in
+            guard newValue else {
+                return
+            }
+            #if canImport(Darwin)
+            sheetSize = .zero
+            #endif
+        }
         .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
             contentView()
                 .getCGSize($sheetSize)
@@ -85,6 +93,14 @@ struct IntrinsicHeightDetentView_ForItems<Host: View, Content: View, Item: Ident
 
     var body: some View {
         hostView
+            .onChange(of: isPresented != nil) { _, newValue in
+                guard newValue else {
+                    return
+                }
+                #if canImport(Darwin)
+                sheetSize = .zero
+                #endif
+            }
             .sheet(item: $isPresented, onDismiss: onDismiss) { item in
                 contentView(item)
                     .getCGSize($sheetSize)
@@ -101,6 +117,15 @@ private struct CGSizeKey: PreferenceKey {
 }
 
 private extension View {
+    static var sizeChangeTolerance: CGFloat { 0.5 }
+    static var androidBottomCompensation: CGFloat { 24.0 }
+
+    func isSignificantSizeChange(from current: CGSize, to next: CGSize) -> Bool {
+        let widthDiff = abs(current.width - next.width)
+        let heightDiff = abs(current.height - next.height)
+        return widthDiff > Self.sizeChangeTolerance || heightDiff > Self.sizeChangeTolerance
+    }
+
     @ViewBuilder
     func intrinsicSheetDetents(_ sheetSize: CGSize) -> some View {
         if sheetSize.height > 0 {
@@ -110,11 +135,17 @@ private extension View {
                 .fixedSize(horizontal: false, vertical: true)
             #else
             self
-                .presentationDetents([.height(sheetSize.height)])
+                .presentationDetents([.height(sheetSize.height + Self.androidBottomCompensation)])
             #endif
         } else {
+            #if canImport(Darwin)
             self
                 .presentationDetents([.medium])
+            #else
+            // Android: avoid opening at .medium to prevent visible jump down when real height arrives.
+            self
+                .presentationDetents([.height(1)])
+            #endif
         }
     }
 
@@ -127,8 +158,26 @@ private extension View {
                 Color.clear
                     .preference(key: CGSizeKey.self, value: proxy.size)
             }.onPreferenceChange(CGSizeKey.self) { value in
-                viewSize.wrappedValue = value
+                updateSheetSize(viewSize, newSize: value)
             }
         )
+    }
+
+    func updateSheetSize(_ viewSize: Binding<CGSize>, newSize: CGSize) {
+        guard newSize.height > 0 else {
+            return
+        }
+
+        #if canImport(Darwin)
+        if isSignificantSizeChange(from: viewSize.wrappedValue, to: newSize) {
+            viewSize.wrappedValue = newSize
+        }
+        #else
+        // Android: lock to the first measured value to avoid recomposition loops.
+        guard viewSize.wrappedValue.height <= 0 else {
+            return
+        }
+        viewSize.wrappedValue = newSize
+        #endif
     }
 }

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -104,9 +104,14 @@ private extension View {
     @ViewBuilder
     func intrinsicSheetDetents(_ sheetSize: CGSize) -> some View {
         if sheetSize.height > 0 {
+            #if canImport(Darwin)
             self
                 .presentationDetents([.height(sheetSize.height)])
                 .fixedSize(horizontal: false, vertical: true)
+            #else
+            self
+                .presentationDetents([.height(sheetSize.height)])
+            #endif
         } else {
             self
                 .presentationDetents([.medium])

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -69,13 +69,10 @@ struct IntrinsicHeightDetentView_ForBool<Host: View, Content: View>: View {
         hostView
         .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
             contentView()
-                #if canImport(Darwin)
                 .getCGSize($sheetSize)
                 .presentationDetents([.height(sheetSize.height)])
+                #if canImport(Darwin)
                 .fixedSize(horizontal: false, vertical: true)
-                #else
-                .getCGSize($sheetSize)
-                .intrinsicSheetDetents(sheetSize)
                 #endif
         }
     }
@@ -93,13 +90,10 @@ struct IntrinsicHeightDetentView_ForItems<Host: View, Content: View, Item: Ident
         hostView
             .sheet(item: $isPresented, onDismiss: onDismiss) { item in
                 contentView(item)
-                    #if canImport(Darwin)
                     .getCGSize($sheetSize)
                     .presentationDetents([.height(sheetSize.height)])
+                    #if canImport(Darwin)
                     .fixedSize(horizontal: false, vertical: true)
-                    #else
-                    .getCGSize($sheetSize)
-                    .intrinsicSheetDetents(sheetSize)
                     #endif
             }
     }
@@ -113,14 +107,6 @@ private struct CGSizeKey: PreferenceKey {
 }
 
 private extension View {
-    static var androidBottomCompensation: CGFloat { 20.0 }
-
-    @ViewBuilder
-    func intrinsicSheetDetents(_ sheetSize: CGSize) -> some View {
-        self
-            .presentationDetents([.height(sheetSize.height + Self.androidBottomCompensation)])
-    }
-
     /// Sets the `View`'s size to the passed `Binding`
     /// - Parameter viewSize: The `Binding` where to store the value
     /// - Returns: a `SwiftUI.View`.

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -67,16 +67,16 @@ struct IntrinsicHeightDetentView_ForBool<Host: View, Content: View>: View {
 
     var body: some View {
         hostView
-        .onChange(of: isPresented) { _, newValue in
-            guard newValue else {
-                return
-            }
-            sheetSize = .zero
-        }
         .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
             contentView()
+                #if canImport(Darwin)
+                .getCGSize($sheetSize)
+                .presentationDetents([.height(sheetSize.height)])
+                .fixedSize(horizontal: false, vertical: true)
+                #else
                 .getCGSize($sheetSize)
                 .intrinsicSheetDetents(sheetSize)
+                #endif
         }
     }
 }
@@ -91,16 +91,16 @@ struct IntrinsicHeightDetentView_ForItems<Host: View, Content: View, Item: Ident
 
     var body: some View {
         hostView
-            .onChange(of: isPresented != nil) { _, newValue in
-                guard newValue else {
-                    return
-                }
-                sheetSize = .zero
-            }
             .sheet(item: $isPresented, onDismiss: onDismiss) { item in
                 contentView(item)
+                    #if canImport(Darwin)
+                    .getCGSize($sheetSize)
+                    .presentationDetents([.height(sheetSize.height)])
+                    .fixedSize(horizontal: false, vertical: true)
+                    #else
                     .getCGSize($sheetSize)
                     .intrinsicSheetDetents(sheetSize)
+                    #endif
             }
     }
 }
@@ -113,29 +113,16 @@ private struct CGSizeKey: PreferenceKey {
 }
 
 private extension View {
-    static var sizeChangeTolerance: CGFloat { 0.5 }
     static var androidBottomCompensation: CGFloat { 24.0 }
-
-    func isSignificantSizeChange(from current: CGSize, to next: CGSize) -> Bool {
-        let widthDiff = abs(current.width - next.width)
-        let heightDiff = abs(current.height - next.height)
-        return widthDiff > Self.sizeChangeTolerance || heightDiff > Self.sizeChangeTolerance
-    }
 
     @ViewBuilder
     func intrinsicSheetDetents(_ sheetSize: CGSize) -> some View {
         if sheetSize.height > 0 {
-            #if canImport(Darwin)
-            self
-                .presentationDetents([.height(sheetSize.height)])
-                .fixedSize(horizontal: false, vertical: true)
-            #else
             self
                 .presentationDetents([.height(sheetSize.height + Self.androidBottomCompensation)])
-            #endif
         } else {
             self
-                .presentationDetents([.medium])
+                .presentationDetents([.height(1)])
         }
     }
 
@@ -158,8 +145,13 @@ private extension View {
             return
         }
 
-        if isSignificantSizeChange(from: viewSize.wrappedValue, to: newSize) {
-            viewSize.wrappedValue = newSize
+        #if canImport(Darwin)
+        viewSize.wrappedValue = newSize
+        #else
+        guard viewSize.wrappedValue.height <= 0 else {
+            return
         }
+        viewSize.wrappedValue = newSize
+        #endif
     }
 }

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -63,21 +63,14 @@ struct IntrinsicHeightDetentView_ForBool<Host: View, Content: View>: View {
     @Binding var isPresented: Bool
     let onDismiss: (() -> Void)?
     
-    #if canImport(Darwin)
     @State var sheetSize: CGSize = .zero
-    #endif
 
     var body: some View {
         hostView
         .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
             contentView()
-                #if canImport(Darwin)
                 .getCGSize($sheetSize)
-                .presentationDetents([.height(sheetSize.height)])
-                .fixedSize(horizontal: false, vertical: true)
-                #else
-                .presentationDetents([.medium])
-                #endif
+                .intrinsicSheetDetents(sheetSize)
         }
     }
 }
@@ -94,19 +87,11 @@ struct IntrinsicHeightDetentView_ForItems<Host: View, Content: View, Item: Ident
         hostView
             .sheet(item: $isPresented, onDismiss: onDismiss) { item in
                 contentView(item)
-                    #if canImport(Darwin)
                     .getCGSize($sheetSize)
-                    .presentationDetents([.height(sheetSize.height)])
-                    .fixedSize(horizontal: false, vertical: true)
-                    #else
-                    .presentationDetents([.medium])
-                    #endif
+                    .intrinsicSheetDetents(sheetSize)
             }
     }
 }
-
-#if canImport(Darwin)
-import SwiftUI
 
 private struct CGSizeKey: PreferenceKey {
     nonisolated(unsafe) static var defaultValue = CGSize.zero
@@ -116,6 +101,18 @@ private struct CGSizeKey: PreferenceKey {
 }
 
 private extension View {
+    @ViewBuilder
+    func intrinsicSheetDetents(_ sheetSize: CGSize) -> some View {
+        if sheetSize.height > 0 {
+            self
+                .presentationDetents([.height(sheetSize.height)])
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            self
+                .presentationDetents([.medium])
+        }
+    }
+
     /// Sets the `View`'s size to the passed `Binding`
     /// - Parameter viewSize: The `Binding` where to store the value
     /// - Returns: a `SwiftUI.View`.
@@ -130,4 +127,3 @@ private extension View {
         )
     }
 }
-#endif

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -113,17 +113,12 @@ private struct CGSizeKey: PreferenceKey {
 }
 
 private extension View {
-    static var androidBottomCompensation: CGFloat { 24.0 }
+    static var androidBottomCompensation: CGFloat { 20.0 }
 
     @ViewBuilder
     func intrinsicSheetDetents(_ sheetSize: CGSize) -> some View {
-        if sheetSize.height > 0 {
-            self
-                .presentationDetents([.height(sheetSize.height + Self.androidBottomCompensation)])
-        } else {
-            self
-                .presentationDetents([.height(1)])
-        }
+        self
+            .presentationDetents([.height(sheetSize.height + Self.androidBottomCompensation)])
     }
 
     /// Sets the `View`'s size to the passed `Binding`

--- a/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
+++ b/Sources/BSWInterfaceKit/SwiftUI/ViewModifiers/IntrinsicHeightSheet.swift
@@ -71,9 +71,7 @@ struct IntrinsicHeightDetentView_ForBool<Host: View, Content: View>: View {
             guard newValue else {
                 return
             }
-            #if canImport(Darwin)
             sheetSize = .zero
-            #endif
         }
         .sheet(isPresented: $isPresented, onDismiss: onDismiss) {
             contentView()
@@ -97,9 +95,7 @@ struct IntrinsicHeightDetentView_ForItems<Host: View, Content: View, Item: Ident
                 guard newValue else {
                     return
                 }
-                #if canImport(Darwin)
                 sheetSize = .zero
-                #endif
             }
             .sheet(item: $isPresented, onDismiss: onDismiss) { item in
                 contentView(item)
@@ -138,14 +134,8 @@ private extension View {
                 .presentationDetents([.height(sheetSize.height + Self.androidBottomCompensation)])
             #endif
         } else {
-            #if canImport(Darwin)
             self
                 .presentationDetents([.medium])
-            #else
-            // Android: avoid opening at .medium to prevent visible jump down when real height arrives.
-            self
-                .presentationDetents([.height(1)])
-            #endif
         }
     }
 
@@ -168,16 +158,8 @@ private extension View {
             return
         }
 
-        #if canImport(Darwin)
         if isSignificantSizeChange(from: viewSize.wrappedValue, to: newSize) {
             viewSize.wrappedValue = newSize
         }
-        #else
-        // Android: lock to the first measured value to avoid recomposition loops.
-        guard viewSize.wrappedValue.height <= 0 else {
-            return
-        }
-        viewSize.wrappedValue = newSize
-        #endif
     }
 }


### PR DESCRIPTION
## Summary
This PR improves `intrinsicHeightSheet` behavior on Android while keeping iOS behavior unchanged.

## What changed
- Kept the existing iOS intrinsic-height implementation as-is:
  - `getCGSize`
  - `.presentationDetents([.height(sheetSize.height)])`
  - `.fixedSize(horizontal: false, vertical: true)`
- Added Android-specific handling for intrinsic detents:
  - Uses `.intrinsicSheetDetents(sheetSize)` with an Android bottom compensation (`+20`).
  - Locks sheet size to the first valid measured height on Android to reduce unnecessary recompositions/height updates.

## Why
On Android (Skip/Compose), the same detent behavior as iOS is not stable enough by default. This adjustment makes the height behavior more predictable while preserving iOS parity.

## Visual comparison

### iOS
https://github.com/user-attachments/assets/12a67405-eefe-46c0-9e6b-6682500e83b6

### Android
[Screen_recording_20260223_170005.webm](https://github.com/user-attachments/assets/29c39bb9-b373-4da0-a5e7-d331d377d86b)


