### PR TITLE
Add injectable localization hook for InterfaceKit strings

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         lfs: true
     - name: Test BSWInterfaceKit iOS
-      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 17,OS=26.4.1" test | xcbeautify --renderer github-actions
+      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" test | xcbeautify --renderer github-actions
   
   macos-build:
     runs-on: mobile

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         lfs: true
     - name: Test BSWInterfaceKit iOS
-      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" test | xcbeautify --renderer github-actions
+      run: set -o pipefail && xcodebuild -scheme BSWInterfaceKit -destination "platform=iOS Simulator,name=iPhone 17,OS=latest" test | xcbeautify --renderer github-actions
   
   macos-build:
     runs-on: mobile

--- a/Sources/BSWInterfaceKit/Extensions/Localizable.swift
+++ b/Sources/BSWInterfaceKit/Extensions/Localizable.swift
@@ -3,6 +3,20 @@ import Foundation
 
 extension String {
     var localized: String {
-        return NSLocalizedString(self, bundle: Bundle.main, comment: "")
+        LocalizationService.localized(self)
+    }
+}
+
+public enum LocalizationService {
+    /// Default localization hook used by InterfaceKit strings.
+    ///
+    /// On Apple platforms, looking up strings from `Bundle.main` works because the
+    /// host app owns the main bundle and ships its localized resources there.
+    /// Other runtimes do not necessarily have an equivalent app bundle lookup.
+    /// Android/Skip apps, in particular, should inject this closure from the host
+    /// app so strings are resolved through the app localization system, resources,
+    /// or any runtime translation provider.
+    public static nonisolated(unsafe) var localized: (String) -> String = {
+        NSLocalizedString($0, bundle: .main, comment: "")
     }
 }


### PR DESCRIPTION
Adds a small localization hook so BSWInterfaceKit strings can be resolved by the host app instead of always using Bundle.main.

On Apple platforms, Bundle.main works for app-owned localized resources. On other runtimes, especially Android/Skip, those strings need to be resolved through the host app localization system.

This keeps the existing Bundle.main behavior as the default while allowing apps to inject a custom resolver, for example to bridge InterfaceKit strings to Android resources or a runtime translation provider.

Example integration in a host app:
```swift
BSWInterfaceKit.ModuleDependencies.localizedString = {
    NaturitasCore.ModuleDependencies.localizationService.localized($0)
}