### PR TITLE
Allow manual Emerge build uploads

### DIFF
--- a/.github/workflows/buildEmerge.yml
+++ b/.github/workflows/buildEmerge.yml
@@ -3,6 +3,7 @@ name: Build Emerge
 on:
   push:
     branches: [develop]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Why

The Emerge baseline build for commit `9ab5b88` was not uploaded because the CI build failed while resolving remote Swift package dependencies.

<img height="300" alt="Screenshot 2026-08-13 at 13 30 49" src="https://github.com/user-attachments/assets/5e6d1f72-edbc-47e8-b66c-c9f35be1d84d" />

As a result, the XCFramework artifact was not generated and the Emerge upload step did not run. The following build could therefore not be compared against that commit.

A new push will likely resolve this automatically because Emerge can compare it against the latest successfully uploaded build.

## What changes

Adds `workflow_dispatch` to the Emerge workflow.

This provides a manual fallback for transient CI or dependency-resolution failures, allowing us to upload a build without requiring a new code change and restore Emerge comparisons more quickly.

## Validation

- YAML syntax validated